### PR TITLE
add orientation lock to QuestionsActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,8 +37,9 @@
             android:name=".QuestionsActivity"
             android:exported="false"
             android:label="@string/title_activity_questions"
-            android:screenOrientation="fullSensor"
-            android:theme="@style/Theme.QuizApp.NoActionBar" /> <!-- activity settings for mainActivity -->
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.QuizApp.NoActionBar"
+            tools:ignore="LockedOrientationActivity" /> <!-- activity settings for mainActivity -->
         <!-- and set screen orientation that will not changed -->
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
@pratyaksh1610 
**Issue:** #20 

**Work Done:**
Locked orientation of QuestionActivity to Portriat so as to prevent data loss due to orientation change.

[Video Link](https://drive.google.com/file/d/1WHVzakrfnkhTCMIj00tDf_R2MMQ7IEOb/view?usp=sharing)